### PR TITLE
[FIX] base: Ability to change user password

### DIFF
--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -23,6 +23,7 @@
                 <!-- the user list is editable, but one cannot add or delete rows -->
                 <tree string="Users" editable="bottom" create="false" delete="false">
                     <field name="user_login"/>
+                    <field name="user_id" invisible="1"/>
                     <field name="new_passwd" required="True" password="True"/>
                 </tree>
             </field>


### PR DESCRIPTION
[odoo:57926](https://github.com/odoo/odoo/issues/57926)

On [Password Change](https://github.com/odoo/odoo/blob/saas-13.5/odoo/addons/base/models/res_users.py#L1526-L1532)  button click it requires [_user_id_](https://github.com/odoo/odoo/blob/saas-13.5/odoo/addons/base/models/res_users.py#L1530
) which isn't set at tree view.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
